### PR TITLE
Adds :phoenix to the list of mix project compilers

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -11,7 +11,8 @@ defmodule PhoenixLiveViewDropzone.MixProject do
       version: @version,
       deps: deps(),
       docs: docs(),
-      package: package()
+      package: package(),
+      compilers: [:phoenix] ++ Mix.compilers()
     ]
   end
 


### PR DESCRIPTION
After updating from 0.0.6 to 0.0.7 any attempt to compile my project resulted in this error:
```
==> phoenix_live_view_dropzone
Compiling 1 file (.ex)

== Compilation error in file lib/phoenix_live_view_dropzone.ex ==
** (RuntimeError) could not load template_engines configuration for Phoenix. Please ensure you have listed :phoenix under :applications in your mix.exs file and have enabled the :phoenix compiler under :compilers, for example: [:phoenix] ++ Mix.compilers
    lib/phoenix/template.ex:257: Phoenix.Template.raw_config/1
    lib/phoenix/template.ex:247: Phoenix.Template.compiled_engines/0
    lib/phoenix/template.ex:319: Phoenix.Template.find_all/2
    expanding macro: Phoenix.LiveView.Renderer.__before_compile__/1
    lib/phoenix_live_view_dropzone.ex:1: PhoenixLiveViewDropzone (module)
could not compile dependency :phoenix_live_view_dropzone, "mix compile" failed. You can recompile this dependency with "mix deps.compile phoenix_live_view_dropzone", update it with "mix deps.update phoenix_live_view_dropzone" or clean it with "mix deps.clean phoenix_live_view_dropzone"
```

After making the proposed change the error goes away.  I'm not sure why this wasn't happening previously so this change might not be the best way to go about this.