### PR TITLE
Reset hover on file drop

### DIFF
--- a/src/Main.elm
+++ b/src/Main.elm
@@ -137,7 +137,7 @@ update msg model =
             ( { model | hover = hover }, Cmd.none )
 
         FileSelected file files ->
-            ( model, file :: files |> List.map (createUpload StartUpload) |> Cmd.batch )
+            ( { model | hover = False }, file :: files |> List.map (createUpload StartUpload) |> Cmd.batch )
 
         StartUpload upload ->
             ( setUpload upload, Ports.requestUrl { id = upload.id, name = upload.name } )


### PR DESCRIPTION
When dropping a file, hover was not being reset to False, leaving my dropzone styled like it is awaiting a drop. 

This PR addresses that by always setting hover to False on every FileSelected msg -- this is perhaps more heavy-handed than necessary/misappropriating the FileSelected msg, but I can't think of a situation that would result in an incorrect hover value. And it didn't seem worth it to me to break out Task chains for that situation, but that or potentially other solutions seem reasonable to me.

Thanks again!